### PR TITLE
fix: remove requests that error from queue

### DIFF
--- a/projects/ngneat/cashew/src/lib/httpCacheInterceptor.ts
+++ b/projects/ngneat/cashew/src/lib/httpCacheInterceptor.ts
@@ -34,10 +34,15 @@ export class HttpCacheInterceptor implements HttpInterceptor {
         return of(this.httpCacheManager.get(key));
       }
       const shared = next.handle(clone).pipe(
-        tap(event => {
-          if (event instanceof HttpResponse) {
-            const cache = this.httpCacheManager._resolveResponse(event);
-            this.httpCacheManager._set(key, cache, +ttl);
+        tap({
+          next: event => {
+            if (event instanceof HttpResponse) {
+              const cache = this.httpCacheManager._resolveResponse(event);
+              this.httpCacheManager._set(key, cache, +ttl);
+            }
+            queue.delete(key);
+          },
+          error: () => {
             queue.delete(key);
           }
         }),


### PR DESCRIPTION
fixes https://github.com/ngneat/cashew/issues/9

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] ~~Docs have been added / updated (for bug fixes / features)~~ (n/a)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

This PR updates the library to remove requests from the cache queue if the request fails.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: https://github.com/ngneat/cashew/issues/9

## What is the new behavior?

Any request that errors is removed from the cache queue. This prevents stale requests being sent from the queue if a request fails.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
