### PR TITLE
feat: add parameter encoder override

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -77,6 +77,16 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "mokipedia",
+      "name": "mokipedia",
+      "avatar_url": "https://avatars3.githubusercontent.com/u/11502273?v=4",
+      "profile": "https://github.com/mokipedia",
+      "contributions": [
+        "code",
+        "doc"
+      ]
     }
   ],
   "contributorsPerLine": 7

--- a/README.md
+++ b/README.md
@@ -136,6 +136,39 @@ HttpCacheInterceptorModule.forRoot({
 });
 ```
 
+#### `parameterCodec`
+
+Define the `HttpParameterCodec` implementation if you need a different parameter encoder.
+
+Example of custom implementation that uses `encodeURIComponent`:
+
+```ts
+import { HttpCacheInterceptorModule, useHttpCacheLocalStorage } from '@ngneat/cashew';
+import { HttpParameterCodec } from '@angular/common/http';
+
+class CustomHttpParameterCodec implements HttpParameterCodec {
+  encodeKey(key: string): string {
+    return encodeURIComponent(key);
+  }
+  encodeValue(value: string): string {
+    return encodeURIComponent(value);
+  }
+  decodeKey(key: string): string {
+    return decodeURIComponent(key);
+  }
+  decodeValue(value: string): string {
+    return decodeURIComponent(value);
+  }
+}
+
+@NgModule({
+  imports: [HttpClientModule, HttpCacheInterceptorModule.forRoot({ parameterCodec: new CustomHttpParameterCodec()})],
+  providers: [useHttpCacheLocalStorage],
+  bootstrap: [AppComponent]
+})
+export class AppModule {}
+
+```
 ## API
 
 ### WithCache

--- a/README.md
+++ b/README.md
@@ -314,6 +314,9 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
     <td align="center"><a href="https://github.com/theblushingcrow"><img src="https://avatars3.githubusercontent.com/u/638818?v=4" width="100px;" alt=""/><br /><sub><b>Inbal Sinai</b></sub></a><br /><a href="https://github.com/ngneat/cashew/commits?author=theblushingcrow" title="Code">💻</a> <a href="https://github.com/ngneat/cashew/commits?author=theblushingcrow" title="Documentation">📖</a></td>
     <td align="center"><a href="https://binary.com.au"><img src="https://avatars2.githubusercontent.com/u/175909?v=4" width="100px;" alt=""/><br /><sub><b>James Manners</b></sub></a><br /><a href="https://github.com/ngneat/cashew/commits?author=jmannau" title="Code">💻</a></td>
   </tr>
+  <tr>
+    <td align="center"><a href="https://github.com/mokipedia"><img src="https://avatars3.githubusercontent.com/u/11502273?v=4" width="100px;" alt=""/><br /><sub><b>mokipedia</b></sub></a><br /><a href="https://github.com/ngneat/cashew/commits?author=mokipedia" title="Code">💻</a> <a href="https://github.com/ngneat/cashew/commits?author=mokipedia" title="Documentation">📖</a></td>
+  </tr>
 </table>
 
 <!-- markdownlint-enable -->

--- a/projects/ngneat/cashew/src/lib/cloneWithoutParams.ts
+++ b/projects/ngneat/cashew/src/lib/cloneWithoutParams.ts
@@ -1,12 +1,19 @@
-import { HttpParams } from '@angular/common/http';
+import { HttpParameterCodec, HttpParams } from '@angular/common/http';
 import { filterParams } from './filterParams';
 import { HttpCacheRequest } from './types';
 
-export function cloneWithoutParams(request: HttpCacheRequest, customKey: string): HttpCacheRequest {
+export function cloneWithoutParams(
+  request: HttpCacheRequest,
+  customKey: string,
+  parameterCodec?: HttpParameterCodec
+): HttpCacheRequest {
   const filteredParams = filterParams(request);
 
   const clone = request.clone({
-    params: new HttpParams({ fromObject: filteredParams })
+    params: new HttpParams({
+      fromObject: filteredParams,
+      ...(parameterCodec && { encoder: parameterCodec })
+    })
   });
 
   (clone as HttpCacheRequest).customKey = customKey;

--- a/projects/ngneat/cashew/src/lib/httpCacheConfig.ts
+++ b/projects/ngneat/cashew/src/lib/httpCacheConfig.ts
@@ -1,3 +1,4 @@
+import { HttpParameterCodec } from '@angular/common/http';
 import { InjectionToken } from '@angular/core';
 import { CacheBucket } from './cacheBucket';
 
@@ -6,6 +7,7 @@ export interface HttpCacheConfig {
   ttl: number;
   responseSerializer?: (value: any) => any;
   localStorageKey?: string;
+  parameterCodec?: HttpParameterCodec;
 }
 
 export const defaultConfig: HttpCacheConfig = {

--- a/projects/ngneat/cashew/src/lib/test/cloneWithoutParams.spec.ts
+++ b/projects/ngneat/cashew/src/lib/test/cloneWithoutParams.spec.ts
@@ -1,0 +1,24 @@
+import { HttpParams } from '@angular/common/http';
+import { cloneWithoutParams } from '../cloneWithoutParams';
+import { CustomHttpParamsCodec, httpRequest } from './mocks.spec';
+
+describe('cloneWithoutParams', () => {
+  let request = (params, method = 'GET', url = 'api/mock') =>
+    httpRequest(method, { params: new HttpParams({ fromObject: params }) }, url);
+
+  it('should encode cloned params with angular default http params codec', () => {
+    const params = { param: '+/:_- encoded' };
+    const clone = cloneWithoutParams(request(params), '');
+
+    expect(clone.params.toString()).toBe(new HttpParams({ fromObject: params }).toString());
+  });
+
+  it('should encode cloned params with custom http params codec', () => {
+    const params = { param: '+/:_- encoded' };
+    const parameterCodec = new CustomHttpParamsCodec();
+
+    const clone = cloneWithoutParams(request(params), '', parameterCodec);
+
+    expect(clone.params.toString()).toBe(new HttpParams({ fromObject: params, encoder: parameterCodec }).toString());
+  });
+});

--- a/projects/ngneat/cashew/src/lib/test/httpCacheInterceptor.spec.ts
+++ b/projects/ngneat/cashew/src/lib/test/httpCacheInterceptor.spec.ts
@@ -22,7 +22,7 @@ describe('HttpCacheInterceptor', () => {
 
   beforeEach(() => {
     handler = httpHandler();
-    httpCacheInterceptor = new HttpCacheInterceptor(httpCacheManager(), keySerializer());
+    httpCacheInterceptor = new HttpCacheInterceptor(httpCacheManager(), keySerializer(), config);
     expect.hasAssertions();
   });
 
@@ -54,7 +54,7 @@ describe('HttpCacheInterceptor', () => {
   it('should cache a return a serialized request when passing a serializer', fakeAsync(() => {
     const responseSerializer = jest.fn(v => 'serialized');
     const cacheManager: any = httpCacheManager({ ...config, responseSerializer });
-    httpCacheInterceptor = new HttpCacheInterceptor(cacheManager, keySerializer());
+    httpCacheInterceptor = new HttpCacheInterceptor(cacheManager, keySerializer(), config);
     call(request({ cache$: true }));
     expect(handler.handle).toHaveBeenCalledTimes(1);
     /* The serializer is called when adding the value to the cache and when retrieving it */
@@ -65,7 +65,8 @@ describe('HttpCacheInterceptor', () => {
   it('should cache the request by default on implicit strategy', fakeAsync(() => {
     httpCacheInterceptor = new HttpCacheInterceptor(
       httpCacheManager({ ...config, strategy: 'implicit' }),
-      keySerializer()
+      keySerializer(),
+      config
     );
     call(request({}));
     expect(handler.handle).toHaveBeenCalledTimes(1);
@@ -74,7 +75,8 @@ describe('HttpCacheInterceptor', () => {
   it('should not cache the request on implicit strategy and cache$ if falsy', fakeAsync(() => {
     httpCacheInterceptor = new HttpCacheInterceptor(
       httpCacheManager({ ...config, strategy: 'implicit' }),
-      keySerializer()
+      keySerializer(),
+      config
     );
     call(request({ cache$: false }));
     expect(handler.handle).toHaveBeenCalledTimes(2);

--- a/projects/ngneat/cashew/src/lib/test/mocks.spec.ts
+++ b/projects/ngneat/cashew/src/lib/test/mocks.spec.ts
@@ -1,4 +1,4 @@
-import { HttpRequest, HttpResponse, HttpHeaders, HttpParams } from '@angular/common/http';
+import { HttpRequest, HttpResponse, HttpHeaders, HttpParams, HttpParameterCodec } from '@angular/common/http';
 import { CacheBucket } from '../cacheBucket';
 import { defaultConfig } from '../httpCacheConfig';
 import { DefaultHttpCacheGuard } from '../httpCacheGuard';
@@ -50,4 +50,18 @@ export function localStorageMock() {
     };
   })();
   Object.defineProperty(window, 'localStorage', { value: localStorageMock });
+}
+export class CustomHttpParamsCodec implements HttpParameterCodec {
+  public decodeKey(key: string): string {
+    return decodeURIComponent(key);
+  }
+  public decodeValue(value: string): string {
+    return decodeURIComponent(value);
+  }
+  public encodeKey(key: string): string {
+    return encodeURIComponent(key);
+  }
+  public encodeValue(value: string): string {
+    return encodeURIComponent(value);
+  }
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Currently, as the request gets cloned and a new `HttpParams` object is created, there is currently no way to set the encoder (neigher globally, nor for each request)

Issue Number: #13

## What is the new behavior?

A new optional config option is added to provide the `HttpParameterCodec` used for cached requests.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
