### PR TITLE
feat: add local parameter codec override

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,39 @@ class CustomHttpParameterCodec implements HttpParameterCodec {
 export class AppModule {}
 
 ```
+
+or per request:
+```ts
+class CustomHttpParameterCodec implements HttpParameterCodec {
+  encodeKey(key: string): string {
+    return encodeURIComponent(key);
+  }
+  encodeValue(value: string): string {
+    return encodeURIComponent(value);
+  }
+  decodeKey(key: string): string {
+    return decodeURIComponent(key);
+  }
+  decodeValue(value: string): string {
+    return decodeURIComponent(value);
+  }
+}
+
+@Injectable()
+export class UsersService {
+  constructor(private http: HttpClient) {}
+
+  getUsers() {
+    return this.http.get(
+      'api/users',
+      withCache({
+        parameterCodec$: new CustomHttpParameterCodec(),
+        ...
+      })
+    );
+  }
+}
+```
 ## API
 
 ### WithCache

--- a/projects/ngneat/cashew/src/lib/filterParams.ts
+++ b/projects/ngneat/cashew/src/lib/filterParams.ts
@@ -1,6 +1,6 @@
 import { HttpCacheRequest } from './types';
 
-const filterKeys = ['ttl$', 'cache$', 'key$', 'bucket$'];
+const filterKeys = ['ttl$', 'cache$', 'key$', 'bucket$', 'parameterCodec$'];
 
 export function filterParams(request: HttpCacheRequest) {
   return request.params.keys().reduce((acc, key) => {

--- a/projects/ngneat/cashew/src/lib/httpCacheConfig.ts
+++ b/projects/ngneat/cashew/src/lib/httpCacheConfig.ts
@@ -21,6 +21,7 @@ type Params = {
   ttl$?: number;
   key$?: string;
   bucket$?: CacheBucket;
+  parameterCodec$?: HttpParameterCodec;
   [key: string]: any;
 };
 

--- a/projects/ngneat/cashew/src/lib/httpCacheInterceptor.ts
+++ b/projects/ngneat/cashew/src/lib/httpCacheInterceptor.ts
@@ -23,7 +23,10 @@ export class HttpCacheInterceptor implements HttpInterceptor {
     const ttl = request.params.get('ttl$');
     const customKey = request.params.get('key$');
     const bucket: any = request.params.get('bucket$');
-    const { parameterCodec } = this.config;
+
+    const localParameterCodec: any = request.params.get('parameterCodec$');
+    const globalParameterCodec = this.config.parameterCodec;
+    const parameterCodec = localParameterCodec || globalParameterCodec;
 
     const clone = cloneWithoutParams(request, customKey, parameterCodec);
     const key = this.keySerializer.serialize(clone);

--- a/projects/ngneat/cashew/src/lib/test/httpCacheInterceptor.spec.ts
+++ b/projects/ngneat/cashew/src/lib/test/httpCacheInterceptor.spec.ts
@@ -1,9 +1,18 @@
 import { HttpHandler, HttpResponse, HttpParams } from '@angular/common/http';
 import { fakeAsync, tick } from '@angular/core/testing';
-import { EMPTY, throwError, timer } from 'rxjs';
+import { EMPTY, of, throwError, timer } from 'rxjs';
 import { catchError, mapTo, mergeMap } from 'rxjs/operators';
 import { HttpCacheInterceptor } from '../httpCacheInterceptor';
-import { httpCacheManager, keySerializer, httpRequest, config, frame, ttl, cacheBucket } from './mocks.spec';
+import {
+  httpCacheManager,
+  keySerializer,
+  httpRequest,
+  config,
+  frame,
+  ttl,
+  cacheBucket,
+  CustomHttpParamsCodec
+} from './mocks.spec';
 
 describe('HttpCacheInterceptor', () => {
   let httpCacheInterceptor: HttpCacheInterceptor;
@@ -154,5 +163,38 @@ describe('HttpCacheInterceptor', () => {
     spyOn(bucket, 'add');
     call(request({ cache$: true, bucket$: bucket, key$: 'foo' }), 1);
     expect(bucket.add).toHaveBeenCalledWith('foo');
+  }));
+
+  it('should use parameterCodec from request', fakeAsync(() => {
+    const testParam = 'te3/s-+d+_asd:';
+    const expectedParamString = new HttpParams({
+      encoder: new CustomHttpParamsCodec(),
+      fromObject: { testParam }
+    }).toString();
+
+    const handler = {
+      handle: jest.fn(clone => {
+        expect(clone.params.toString()).toBe(expectedParamString);
+        return of(clone);
+      })
+    };
+
+    httpCacheInterceptor
+      .intercept(request({ cache$: true, testParam, parameterCodec$: new CustomHttpParamsCodec() }), handler)
+      .subscribe();
+  }));
+
+  it('should use default codec if neigher config nor request provides custom param codec', fakeAsync(() => {
+    const testParam = 'te3/s-+d+_asd:';
+    const expectedParamString = new HttpParams({ fromObject: { testParam } }).toString();
+
+    const handler = {
+      handle: jest.fn(clone => {
+        expect(clone.params.toString()).toBe(expectedParamString);
+        return of(clone);
+      })
+    };
+
+    httpCacheInterceptor.intercept(request({ cache$: true, testParam }), handler).subscribe();
   }));
 });

--- a/projects/ngneat/cashew/src/lib/test/httpCacheInterceptor.spec.ts
+++ b/projects/ngneat/cashew/src/lib/test/httpCacheInterceptor.spec.ts
@@ -172,29 +172,27 @@ describe('HttpCacheInterceptor', () => {
       fromObject: { testParam }
     }).toString();
 
-    const handler = {
+    handler = {
       handle: jest.fn(clone => {
         expect(clone.params.toString()).toBe(expectedParamString);
-        return of(clone);
+        return of();
       })
     };
 
-    httpCacheInterceptor
-      .intercept(request({ cache$: true, testParam, parameterCodec$: new CustomHttpParamsCodec() }), handler)
-      .subscribe();
+    call(request({ cache$: true, testParam, parameterCodec$: new CustomHttpParamsCodec() }), 1);
   }));
 
   it('should use default codec if neigher config nor request provides custom param codec', fakeAsync(() => {
     const testParam = 'te3/s-+d+_asd:';
     const expectedParamString = new HttpParams({ fromObject: { testParam } }).toString();
 
-    const handler = {
+    handler = {
       handle: jest.fn(clone => {
         expect(clone.params.toString()).toBe(expectedParamString);
-        return of(clone);
+        return of();
       })
     };
 
-    httpCacheInterceptor.intercept(request({ cache$: true, testParam }), handler).subscribe();
+    call(request({ cache$: true, testParam }), 1);
   }));
 });

--- a/projects/ngneat/cashew/src/lib/test/httpCacheInterceptor.spec.ts
+++ b/projects/ngneat/cashew/src/lib/test/httpCacheInterceptor.spec.ts
@@ -172,27 +172,19 @@ describe('HttpCacheInterceptor', () => {
       fromObject: { testParam }
     }).toString();
 
-    handler = {
-      handle: jest.fn(clone => {
-        expect(clone.params.toString()).toBe(expectedParamString);
-        return of();
-      })
-    };
-
     call(request({ cache$: true, testParam, parameterCodec$: new CustomHttpParamsCodec() }), 1);
+
+    const params = (handler.handle as jest.Mock).mock.calls[0][0].params;
+    expect(params.toString()).toBe(expectedParamString);
   }));
 
   it('should use default codec if neigher config nor request provides custom param codec', fakeAsync(() => {
     const testParam = 'te3/s-+d+_asd:';
     const expectedParamString = new HttpParams({ fromObject: { testParam } }).toString();
 
-    handler = {
-      handle: jest.fn(clone => {
-        expect(clone.params.toString()).toBe(expectedParamString);
-        return of();
-      })
-    };
-
     call(request({ cache$: true, testParam }), 1);
+
+    const params = (handler.handle as jest.Mock).mock.calls[0][0].params;
+    expect(params.toString()).toBe(expectedParamString);
   }));
 });


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

Adds the possibility to override parameter codec per request

```
[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

ParameterCodec can be set globally for all requests

## What is the new behavior?

parameterCodec$ in params will override encoder for HttpParams per request

## Does this PR introduce a breaking change?

```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

Note: no tests as I was unable to find a reliable way to programatically test request after interceptor. Input wanted!