### PR TITLE
fix: 🐛 method for View Engine users to pass partial config

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,14 @@ To your `AppModule` providers list. Note that `ttl` will also be calculated via 
 
 ## Config Options
 
-Using the library, you might need to change the default behavior of the caching mechanism. You could do that by passing a configuration object to the static `forRoot` method of the `HttpCacheInterceptorModule` module.
+Using the library, you might need to change the default behavior of the caching mechanism. You could do that by passing a configuration (a partial `HttpCacheConfig` object) to the static `forRoot` method of the `HttpCacheInterceptorModule` module.
+
+
+**Important note:** View Engine users - instead of adding the config to the `forRoot()` method, add it in the app module providers in the following manner, using the supplied `cashewConfig()` method: 
+
+```ts
+{ provide: HTTP_CACHE_CONFIG, useValue: cashewConfig(config) }
+``` 
 
 Let's go over each of the configuration options:
 

--- a/projects/ngneat/cashew/src/lib/httpCacheConfig.ts
+++ b/projects/ngneat/cashew/src/lib/httpCacheConfig.ts
@@ -34,4 +34,14 @@ export function withCache(params: Params = {}): { params: Params } {
   };
 }
 
+export function cashewConfig(config: Partial<HttpCacheConfig> = defaultConfig): HttpCacheConfig {
+  return {
+    strategy: config.strategy || defaultConfig.strategy,
+    ttl: config.ttl || defaultConfig.ttl,
+    localStorageKey: config.localStorageKey || defaultConfig.localStorageKey,
+    responseSerializer: config.responseSerializer,
+    parameterCodec: config.parameterCodec
+  };
+}
+
 export const HTTP_CACHE_CONFIG = new InjectionToken<HttpCacheConfig>('HTTP_CACHE_CONFIG');

--- a/projects/ngneat/cashew/src/lib/test/cashewConfig.spec.ts
+++ b/projects/ngneat/cashew/src/lib/test/cashewConfig.spec.ts
@@ -1,0 +1,31 @@
+import { cashewConfig, defaultConfig } from '../httpCacheConfig';
+
+describe('cashewConfig', () => {
+  const responseSerializer = v => '';
+
+  it('should return the default config when called with an empty object', () => {
+    expect(cashewConfig({})).toEqual(defaultConfig);
+  });
+
+  it('should override the default config values when called with values in the config parameter', () => {
+    const configWithStrategy = cashewConfig({ strategy: 'implicit' });
+    expect(configWithStrategy.ttl).toEqual(defaultConfig.ttl);
+    expect(configWithStrategy.localStorageKey).toEqual(defaultConfig.localStorageKey);
+    expect(configWithStrategy.strategy).toEqual('implicit');
+
+    const configWithTtl = cashewConfig({ ttl: 10000 });
+    expect(configWithTtl.localStorageKey).toEqual(defaultConfig.localStorageKey);
+    expect(configWithTtl.strategy).toEqual(defaultConfig.strategy);
+    expect(configWithTtl.ttl).toEqual(10000);
+
+    const configWithLocalStorageKey = cashewConfig({ localStorageKey: 'x' });
+    expect(configWithLocalStorageKey.strategy).toEqual(defaultConfig.strategy);
+    expect(configWithLocalStorageKey.ttl).toEqual(defaultConfig.ttl);
+    expect(configWithLocalStorageKey.localStorageKey).toEqual('x');
+  });
+
+  it('should retain additional parameters passed in the config, such as responseSerializer', () => {
+    const configWithResponseSerializer = cashewConfig({ responseSerializer });
+    expect(configWithResponseSerializer.responseSerializer({ a: 'a' })).toEqual('');
+  });
+});


### PR DESCRIPTION
cashewConfig() enables View Engine users to pass partial config options
in the module providers

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ x ] The commit message follows our guidelines: CONTRIBUTING.md#commit
- [ x ] Tests for the changes have been added (for bug fixes / features)
- [ x ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ x ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #23 

## What is the new behavior?

cashewConfig() enables View Engine users to pass partial config options in the module providers

## Does this PR introduce a breaking change?

```
[ ] Yes
[ x ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
