### PR TITLE
feat: allow passing existing `HttpContext` to `withCache` function

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,9 @@ Currently, there is no way in Angular to pass `metadata` to an interceptor. The 
 - `ttl` - TTL that will override the global
 - `key` - Custom key. (defaults to the request URL including any query params)
 - `bucket` - The [bucket](#cachebucket) in which we save the keys
+- `version` - To use when working with `localStorage` (see [Versioning](###Versioning)).
 - `clearCachePredicate(currentRequest, nextRequest)` - Return `true` to clear the cache for this key
+- `context` - Allow chaining function call that returns an `HttpContext`.
   
 ```ts
 import { requestDataChanged, withCache } from '@ngneat/cashew';
@@ -181,17 +183,17 @@ export class UsersService {
           ttl: 40000,
           key: 'users',
           clearCachePredicate: requestDataChanged
-      })}
+        }),
+      }
     );
   }
 }
 ```
 
-The `withCache` function accepts a second optional argument that allows you to pass an existing `HttpContext`. This allows you to "chain" different functions that return a `HttpContext`.
-
+When you need to call another function that returns an `HttpContext`, you can provide the context option.
 ```ts
 import { withCache } from '@ngneat/cashew';
-import { withLoadingSpinner } from '../with-loading-spinner'; // <= function that adds data to HttpContext
+import { withLoadingSpinner } from '@another/library'; // <-- function that returns an HttpContext
 
 @Injectable()
 export class TodosService {
@@ -200,8 +202,10 @@ export class TodosService {
   getTodos() {
     return this.http.get(
       'api/todos',
-      {
-        context: withCache({}, withLoadingSpinner('todos')),
+      { 
+        context: withCache({
+          context: withLoadingSpinner(),
+        }),
       }
     );
   }

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ export class UsersService {
 }
 ```
 
-The `withCache` function accept a second optional argument that allows you to pass an existing `HttpContext`. This allows you to "chain" different functions that return a `HttpContext`.
+The `withCache` function accepts a second optional argument that allows you to pass an existing `HttpContext`. This allows you to "chain" different functions that return a `HttpContext`.
 
 ```ts
 import { withCache } from '@ngneat/cashew';

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ Currently, there is no way in Angular to pass `metadata` to an interceptor. The 
 - `ttl` - TTL that will override the global
 - `key` - Custom key. (defaults to the request URL including any query params)
 - `bucket` - The [bucket](#cachebucket) in which we save the keys
-- `version` - To use when working with `localStorage` (see [Versioning](###Versioning)).
+- `version` - To use when working with `localStorage` (see [Versioning](#Versioning)).
 - `clearCachePredicate(currentRequest, nextRequest)` - Return `true` to clear the cache for this key
 - `context` - Allow chaining function call that returns an `HttpContext`.
   

--- a/README.md
+++ b/README.md
@@ -187,6 +187,27 @@ export class UsersService {
 }
 ```
 
+The `withCache` function accept a second optional argument that allows you to pass an existing `HttpContext`. This allows you to "chain" different functions that return a `HttpContext`.
+
+```ts
+import { withCache } from '@ngneat/cashew';
+import { withLoadingSpinner } from '../with-loading-spinner'; // <= function that adds data to HttpContext
+
+@Injectable()
+export class TodosService {
+  constructor(private http: HttpClient) {}
+
+  getTodos() {
+    return this.http.get(
+      'api/todos',
+      {
+        context: withCache({}, withLoadingSpinner('todos')),
+      }
+    );
+  }
+}
+```
+
 ### CacheManager
 
 The `CacheManager` provider, exposes an API to update and query the cache registry:

--- a/projects/ngneat/cashew/src/lib/cache-context.ts
+++ b/projects/ngneat/cashew/src/lib/cache-context.ts
@@ -12,13 +12,15 @@ export interface ContextOptions {
     nextRequest: HttpRequest<T>,
     key: string
   ): boolean;
+  context?: HttpContext;
 }
 
 export const CACHE_CONTEXT = new HttpContextToken<ContextOptions>(() => ({}));
 
-export function withCache(options: ContextOptions = {}, existingHttpContext?: HttpContext) {
-  return (existingHttpContext ?? new HttpContext()).set(CACHE_CONTEXT, {
+export function withCache(options: ContextOptions = {}) {
+  const { context, ...remainingOptions } = options;
+  return (context ?? new HttpContext()).set(CACHE_CONTEXT, {
     cache: true,
-    ...options
+    ...remainingOptions
   });
 }

--- a/projects/ngneat/cashew/src/lib/cache-context.ts
+++ b/projects/ngneat/cashew/src/lib/cache-context.ts
@@ -16,8 +16,8 @@ export interface ContextOptions {
 
 export const CACHE_CONTEXT = new HttpContextToken<ContextOptions>(() => ({}));
 
-export function withCache(options: ContextOptions = {}) {
-  return new HttpContext().set(CACHE_CONTEXT, {
+export function withCache(options: ContextOptions = {}, existingHttpContext?: HttpContext) {
+  return (existingHttpContext ?? new HttpContext()).set(CACHE_CONTEXT, {
     cache: true,
     ...options
   });

--- a/projects/ngneat/cashew/src/lib/specs/cache-context.spec.ts
+++ b/projects/ngneat/cashew/src/lib/specs/cache-context.spec.ts
@@ -1,0 +1,26 @@
+import { HttpContext, HttpContextToken } from '@angular/common/http';
+import { CACHE_CONTEXT, withCache } from '../cache-context';
+
+describe('withCache', () => {
+  const token = new HttpContextToken<number>(() => 0);
+
+  it('should reuse existing HttpContext when provided', () => {
+    const existingContext = new HttpContext().set(token, 42);
+
+    const result = withCache({ cache: true, ttl: 60000 }, existingContext);
+    expect(result === existingContext).toBeTruthy();
+    const allTokens = Array.from(result.keys());
+    expect(allTokens.length).toEqual(2);
+    expect(result.get(CACHE_CONTEXT)).toEqual({ cache: true, ttl: 60000 });
+    expect(result.get(token)).toEqual(42);
+  });
+
+  it('should create a new HttpContext when no existing context exists', () => {
+    const result = withCache({ cache: true, ttl: 60000 });
+    expect(result).toBeDefined();
+    const allTokens = Array.from(result.keys());
+    expect(allTokens.length).toEqual(1);
+    expect(result.get(CACHE_CONTEXT)).toEqual({ cache: true, ttl: 60000 });
+    expect(result.get(token)).toEqual(0);
+  });
+});

--- a/projects/ngneat/cashew/src/lib/specs/cache-context.spec.ts
+++ b/projects/ngneat/cashew/src/lib/specs/cache-context.spec.ts
@@ -7,7 +7,7 @@ describe('withCache', () => {
   it('should reuse existing HttpContext when provided', () => {
     const existingContext = new HttpContext().set(token, 42);
 
-    const result = withCache({ cache: true, ttl: 60000 }, existingContext);
+    const result = withCache({ cache: true, ttl: 60000, context: existingContext });
     expect(result === existingContext).toBeTruthy();
     const allTokens = Array.from(result.keys());
     expect(allTokens.length).toEqual(2);


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

When you use the withCache() function in a HttpClient method, it needs to be assigned to the context option. How do you add something else to the HttpRequest context ?

Issue Number: #42

## What is the new behavior?

Add a second argument to `withCache` function to pass an optional existing `HttpContext` returned from another function (similar to `withCache`).
If the existing `HttpContext` has been provided, the function will use it; otherwise, the function will create a new `HttpContext`.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
