### PR TITLE
fix(local-storage): removes duplicate createKey calls

### DIFF
--- a/projects/ngneat/cashew/src/lib/local-storage/local-storage-cache.ts
+++ b/projects/ngneat/cashew/src/lib/local-storage/local-storage-cache.ts
@@ -45,8 +45,8 @@ export class HttpCacheLocalStorage extends HttpCacheStorage {
 
   clear() {
     super.forEach((value, key) => {
-      super.delete(createKey(key));
-      storage.clearItem(createKey(key));
+      super.delete(key);
+      storage.clearItem(key);
     });
   }
 }

--- a/projects/ngneat/cashew/src/lib/local-storage/local-storage-ttl.ts
+++ b/projects/ngneat/cashew/src/lib/local-storage/local-storage-ttl.ts
@@ -52,8 +52,8 @@ export class LocalStorageTTLManager extends TTLManager {
 
   clear() {
     this.ttl.forEach((_: any, key: string) => {
-      this.ttl.delete(createKey(key));
-      storage.clearItem(createKey(key));
+      this.ttl.delete(key);
+      storage.clearItem(key);
     });
   }
 }

--- a/projects/ngneat/cashew/src/lib/specs/local-storage-ttl-manager.spec.ts
+++ b/projects/ngneat/cashew/src/lib/specs/local-storage-ttl-manager.spec.ts
@@ -38,10 +38,12 @@ describe('localStorageTtlManager', () => {
 
   describe('delete', () => {
     it('should clear storage when call without a key', () => {
-      ttlManager.set('foo', 33);
+      const key = 'foo';
+      ttlManager.set(key, 33);
       jest.spyOn(localStorage, 'removeItem');
       ttlManager.clear();
       expect(localStorage.removeItem).toHaveBeenCalled();
+      expect(ttlManager.has(key)).toBeFalsy();
     });
 
     it('should call delete when given key', () => {
@@ -50,6 +52,7 @@ describe('localStorageTtlManager', () => {
       ttlManager.delete('key');
       expect((ttlManager as any).ttl.delete).toHaveBeenCalled();
       expect(localStorage.removeItem).toHaveBeenCalled();
+      expect(ttlManager.has('key')).toBeFalsy();
     });
   });
 });

--- a/projects/ngneat/cashew/src/lib/specs/local-storage.spec.ts
+++ b/projects/ngneat/cashew/src/lib/specs/local-storage.spec.ts
@@ -38,15 +38,19 @@ describe('httpCacheLocalStorage', () => {
 
   describe('delete', () => {
     it('should clear storage when call without a key', () => {
+      expect(storage.has(existingKey)).toBeTruthy();
       jest.spyOn(localStorage, 'removeItem');
       storage.clear();
       expect(localStorage.removeItem).toHaveBeenCalled();
+      expect(storage.has(existingKey)).toBeFalsy();
     });
 
     it('should call delete when given key', () => {
+      expect(storage.has(existingKey)).toBeTruthy();
       jest.spyOn(localStorage, 'removeItem');
       storage.delete(existingKey);
       expect(localStorage.removeItem).toHaveBeenCalled();
+      expect(storage.has(existingKey)).toBeFalsy();
     });
   });
 });


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Clearing cache while using the Localstorage strategy does not remove the cache and ttl from local storage.

Issue Number: #76

## What is the new behavior?
calling `clear()` will now successfully removes respective cache items from localstorage.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

this is my first PR. yay :tada: 
